### PR TITLE
Fix linker warnings on debian systems

### DIFF
--- a/GCC_Rules.mk
+++ b/GCC_Rules.mk
@@ -33,7 +33,7 @@ LD_SCRIPT = $(CONFIG_DIR)/$(TARGET_MCU).ld
 USER_CFLAGS = -Wall -g -ffunction-sections -fdata-sections -O3
 
 # user LD flags
-USER_LDFLAGS = -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
+USER_LDFLAGS = -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections --specs=nano.specs --specs=nosys.specs
 
 #######################################
 # binaries

--- a/Source/system.c
+++ b/Source/system.c
@@ -358,3 +358,11 @@ eFeedback system_set_option_bytes(eOptionBytes e_Option)
     return FBK_Success;
 }
 
+void __weak _close(void) {
+}
+void __weak _lseek(void) {
+}
+void __weak _read(void) {
+}
+void __weak _write(void) {
+}


### PR DESCRIPTION
Closes: https://github.com/Elmue/CANable-2.5-firmware-Slcan-and-Candlelight/issues/19#issuecomment-4226421575