### PR TITLE
settings: include stdbool.h instead of defining false and true using an enum

### DIFF
--- a/Source/settings.h
+++ b/Source/settings.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdio.h>
@@ -17,12 +18,6 @@
 
 // ============================================================================================
 // The following enums are used for Slcan and Candlelight
-
-typedef enum
-{
-    false = 0,
-    true  = 1,
-} bool;
 
 // If command feedback is enabled these error codes are sent to the host.
 // This enum is used for Slcan and for Candlelight.


### PR DESCRIPTION
Closes: https://github.com/Elmue/CANable-2.5-firmware-Slcan-and-Candlelight/issues/26