### PR TITLE
Fix legacy-mode blob misparse: monotonic echo_id stalls TX after 4096 frames

### DIFF
--- a/Firmware/Candlelight/buffer.c
+++ b/Firmware/Candlelight/buffer.c
@@ -251,7 +251,11 @@ void buf_process_can(uint8_t channel, buf_class* can_buf)
 void buf_store_can_frame_blob(uint8_t channel, uint8_t* can_frame)
 {
     kBlob* blob = (kBlob*)can_frame;
-    if (blob->msg_type == MSG_TxBlob)
+    // Blobs exist only in the ElmueSoft protocol. In legacy mode byte[1] is the
+    // echo_id byte 1, so without this GLB_ProtoElmue guard a legacy frame whose
+    // echo_id byte 1 == MSG_TxBlob (0x10) is misparsed as a blob and the classic
+    // frame is dropped/garbled. A monotonic echo_id triggers this at 4096 frames.
+    if (GLB_ProtoElmue && blob->msg_type == MSG_TxBlob)
     {
         int offset = sizeof(kBlob);
         for (uint8_t i=0; i<blob->frame_count; i++)


### PR DESCRIPTION
## Summary

In **legacy** gs_usb / Candlelight mode, a host that transmits with a monotonically increasing
`echo_id` stalls after **exactly 4096 transmitted frames**. `buf_store_can_frame_blob()` checks
`byte[1] == MSG_TxBlob` unconditionally to detect an ElmueSoft blob, but in legacy mode
`byte[1]` is `echo_id` byte 1 — so a legacy frame is misparsed as a blob. This PR guards the
check with `GLB_ProtoElmue`.

This is a regression in the ElmueSoft blob path — it does **not** exist in stock candleLight
(which has no blob layer and treats `echo_id` as opaque).

## Symptom

A host that opens the adapter in legacy Candlelight mode (does **not** set
`ELM_DevFlagProtocolElmue`) and transmits continuously stalls after exactly 4096 frames. From
that point the firmware rejects classic frames with `APP_CanTxFail` (error frame,
`data[5] = 0x02`) and stops forwarding them. It self-recovers after 256 more transmits, then
repeats every 65536 frames. The CAN bus is healthy throughout (TEC = 0, not bus-off) — the
trigger is purely the host's transmit count, independent of bitrate and bus load.

## Root cause

Every host frame from the USB OUT endpoint passes through `buf_store_can_frame_blob()`:

```c
void buf_store_can_frame_blob(uint8_t channel, uint8_t* can_frame)
{
    kBlob* blob = (kBlob*)can_frame;
    if (blob->msg_type == MSG_TxBlob)   // runs in legacy mode too
    { ... parse as an ElmueSoft blob ... }
    buf_store_can_frame(channel, can_frame);
}
```

`kBlob` overlays the frame so `blob->msg_type` is **byte[1]**. Blobs only exist in the
ElmueSoft protocol, but this check runs unconditionally — including in **legacy** mode, where
byte[1] is `kHostFrameLegacy.echo_id` byte 1.

`MSG_TxBlob == 0x10`. A legacy host using a monotonic `echo_id` sets byte[1] = 0x10 as soon as
`echo_id` reaches **0x1000 (4096)**. The frame is misinterpreted as a blob, mis-parsed (2-byte
shift), and the resulting garbage frame carries a phantom `FRM_FDF` flag → rejected in classic
mode. This persists while `echo_id` is in `[0x1000..0x10FF]` (256 frames), i.e. until
byte[1] != 0x10, and recurs every 65536.

## Fix

Guard the blob check on the active protocol:

```diff
     kBlob* blob = (kBlob*)can_frame;
-    if (blob->msg_type == MSG_TxBlob)
+    // Blobs exist only in the ElmueSoft protocol. In legacy mode byte[1] is the
+    // echo_id byte 1, so without this GLB_ProtoElmue guard a legacy frame whose
+    // echo_id byte 1 == MSG_TxBlob (0x10) is misparsed as a blob and the classic
+    // frame is dropped/garbled. A monotonic echo_id triggers this at 4096 frames.
+    if (GLB_ProtoElmue && blob->msg_type == MSG_TxBlob)
```

## How to reproduce / verify (no vehicle needed)

Open the adapter in legacy Candlelight mode, internal loopback, and transmit >4096 frames with
a monotonic `echo_id`. On stock firmware, error frames (`can_id` has the `CAN_ID_Error` bit,
`data[5] = 0x02`) begin at ~frame 4096; with the patch, zero.

Measured on STM32G431 Multiboard, 5000 frames, internal loopback:

| firmware | host echo_id | error frames |
|----------|--------------|--------------|
| stock | monotonic | 245 |
| stock | masked to 8 bits | 0 |
| **patched** | **monotonic** | **0** |

A host can also dodge the bug on stock firmware by keeping `echo_id` byte 1 = 0 (mask to
8 bits) — but the firmware guard is the correct fix, since the current check is wrong for every
legacy-mode host.
